### PR TITLE
Fix CI pnpm step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - run: corepack prepare pnpm@10.12.1 --activate
+      - name: Enable Corepack and prepare pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.12.1 --activate
+          pnpm --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm build


### PR DESCRIPTION
## Summary
- enable corepack before preparing pnpm in GitHub CI workflow

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_684ef566617c83338bc0c900ef3b1915