### PR TITLE
Use LazyHydrate component in HydrationButton

### DIFF
--- a/src/components/HydrationButton.vue
+++ b/src/components/HydrationButton.vue
@@ -1,9 +1,9 @@
 <template>
-  <div v-lazy-hydrate>
+  <LazyHydrate when-visible>
     <button class="px-2 py-1 bg-gray-200 rounded" @click="count++">
       Clicked {{ count }} times
     </button>
-  </div>
+  </LazyHydrate>
 </template>
 
 <script setup lang="ts">

--- a/src/components/LazyExample.spec.ts
+++ b/src/components/LazyExample.spec.ts
@@ -4,7 +4,15 @@ import HydrationButton from './HydrationButton.vue'
 
 describe('HydrationButton', () => {
   it('increments on click', async () => {
-    const wrapper = mount(HydrationButton)
+    const wrapper = mount(HydrationButton, {
+      global: {
+        stubs: {
+          LazyHydrate: {
+            template: '<div><slot /></div>'
+          }
+        }
+      }
+    })
     await wrapper.find('button').trigger('click')
     expect(wrapper.text()).toContain('1')
   })


### PR DESCRIPTION
## Summary
- wrap HydrationButton button with `<LazyHydrate>`
- stub LazyHydrate in tests
- keep plugin registration for LazyHydrate

## Testing
- `pnpm lint`
- `pnpm test -- --run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684ef6fa00588333bc05fe49b593d4ef