### PR TITLE
Fix Storybook env error during dev

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,14 @@
 import { defineNuxtConfig } from 'nuxt/config'
 import { nuxt } from '@storybook-vue/nuxt'
 
+// Storybook's Vue preset expects a browser-like global `window` object even
+// when executed in Node during Nuxt's module initialization. Creating a stub
+// avoids `STORYBOOK_ENV` assignment errors when starting the dev server.
+const g = globalThis as unknown as { window?: unknown }
+if (typeof g.window === 'undefined') {
+  g.window = g
+}
+
 export default defineNuxtConfig({
   stories: ['../src/**/*.stories.@(js|ts|mdx)'],
   addons: ['@storybook/addon-essentials'],


### PR DESCRIPTION
## Summary
- stub a global `window` for storybook so Nuxt dev starts without errors

## Testing
- `pnpm lint`
- `pnpm test` *(terminates in watch mode after successful run)*

------
https://chatgpt.com/codex/tasks/task_e_684f1bfc787483338f602ca746bf5c10