### PR TITLE
Update API client test for new spec

### DIFF
--- a/src/api/client.spec.ts
+++ b/src/api/client.spec.ts
@@ -2,11 +2,11 @@ import { describe, it, expectTypeOf } from 'vitest'
 import type { paths, operations } from './client'
 
 describe('API client types', () => {
-  it('exposes prompt text endpoint', () => {
-    expectTypeOf<paths>().toHaveProperty('/prompt/text')
+  it('exposes version details endpoint', () => {
+    expectTypeOf<paths>().toHaveProperty('/v2')
   })
 
-  it('maps get operation to prompt', () => {
-    expectTypeOf<paths['/prompt/text']['get']>().toEqualTypeOf<operations['prompt']>()
+  it('maps get operation to getVersionDetailsv2', () => {
+    expectTypeOf<paths['/v2']['get']>().toEqualTypeOf<operations['getVersionDetailsv2']>()
   })
 })


### PR DESCRIPTION
## Summary
- update API client type test to check the `/v2` path
- ensure GET operation maps to `getVersionDetailsv2`

## Testing
- `pnpm lint`
- `pnpm generate` *(fails: `Exiting due to prerender errors`)*
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_684f369143a083339c8bd6166ce5a48f