### PR TITLE
Use LazyHydrate component

### DIFF
--- a/src/components/HydrationButton.vue
+++ b/src/components/HydrationButton.vue
@@ -1,9 +1,9 @@
 <template>
-  <div v-lazy-hydrate>
+  <LazyHydrate>
     <button class="px-2 py-1 bg-gray-200 rounded" @click="count++">
       Clicked {{ count }} times
     </button>
-  </div>
+  </LazyHydrate>
 </template>
 
 <script setup lang="ts">

--- a/src/components/LazyExample.spec.ts
+++ b/src/components/LazyExample.spec.ts
@@ -4,7 +4,13 @@ import HydrationButton from './HydrationButton.vue'
 
 describe('HydrationButton', () => {
   it('increments on click', async () => {
-    const wrapper = mount(HydrationButton)
+    const wrapper = mount(HydrationButton, {
+      global: {
+        stubs: {
+          LazyHydrate: { template: '<div><slot /></div>' }
+        }
+      }
+    })
     await wrapper.find('button').trigger('click')
     expect(wrapper.text()).toContain('1')
   })


### PR DESCRIPTION
## Summary
- replace `v-lazy-hydrate` directive with `<LazyHydrate>` component
- stub `LazyHydrate` in tests

## Testing
- `pnpm lint`
- `pnpm generate` *(fails: Server Error)*
- `pnpm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_684f36a6629c8333aeb5461d18c5fd85