### PR TITLE
feat: add lazy hero component

### DIFF
--- a/src/components/Hero.spec.ts
+++ b/src/components/Hero.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Hero from './Hero.vue'
+
+describe('Hero', () => {
+  it('renders title and subtitle', () => {
+    const wrapper = mount(Hero, {
+      props: { title: 'Hello', subtitle: 'World' },
+      global: { stubs: { LazyHydrate: { template: '<div><slot /></div>' } } }
+    })
+    expect(wrapper.text()).toContain('Hello')
+    expect(wrapper.text()).toContain('World')
+  })
+})

--- a/src/components/Hero.stories.ts
+++ b/src/components/Hero.stories.ts
@@ -1,0 +1,15 @@
+import Hero from './Hero.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Hero> = {
+  component: Hero,
+  title: 'Hero'
+}
+export default meta
+
+export const Default: StoryObj<typeof Hero> = {
+  render: () => ({
+    components: { Hero },
+    template: '<Hero title="Bienvenue" subtitle="Découvrez Nudger" />'
+  })
+}

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -1,0 +1,17 @@
+<template>
+  <LazyHydrate when-idle>
+    <section class="py-16 text-center bg-gray-100 rounded">
+      <h1 class="mb-2 text-5xl font-bold">{{ title }}</h1>
+      <p v-if="subtitle" class="text-xl text-gray-600">{{ subtitle }}</p>
+    </section>
+  </LazyHydrate>
+</template>
+
+<script setup lang="ts">
+export interface HeroProps {
+  title: string
+  subtitle?: string
+}
+
+defineProps<HeroProps>()
+</script>

--- a/src/pages/index.spec.ts
+++ b/src/pages/index.spec.ts
@@ -4,7 +4,9 @@ import IndexPage from './index.vue'
 
 describe('Index page', () => {
   it('renders welcome text', () => {
-    const wrapper = mount(IndexPage)
+    const wrapper = mount(IndexPage, {
+      global: { stubs: { LazyHydrate: { template: '<div><slot /></div>' } } }
+    })
     expect(wrapper.text()).toContain('Welcome to Nudger !')
   })
 })

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,7 +1,13 @@
 <template>
-  <Card>Welcome to Nudger !</Card>
+  <div class="space-y-4">
+    <Card>Welcome to Nudger !</Card>
+    <Hero title="Nudger" subtitle="Prenez le contrôle de vos finances" />
+  </div>
 </template>
 
 <script setup lang="ts">
 import Card from '@/components/Card.vue'
+import { defineAsyncComponent } from 'vue'
+
+const Hero = defineAsyncComponent(() => import('@/components/Hero.vue'))
 </script>


### PR DESCRIPTION
## Summary
- create `Hero` component with lazy hydration
- show `Hero` on the homepage
- add Storybook story for `Hero`
- test `Hero` and page updates

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_684f5d33b98c8333b27f41e710080297