### PR TITLE
Update Storybook workflow

### DIFF
--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -1,6 +1,7 @@
 name: Storybook Preview
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build:
@@ -8,6 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm storybook:build


### PR DESCRIPTION
## Summary
- cache pnpm in Storybook workflow using `actions/setup-node@v4`
- automatically build preview on pull requests

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_684f5df771948333af2445295f6533b0