### PR TITLE
Add node setup to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+
       - uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
       - run: pnpm install --frozen-lockfile
       - run: pnpm build


### PR DESCRIPTION
## Summary
- install Node 18 with caching before pnpm setup in CI
- do the same for deploy-static and storybook-preview

## Testing
- `pnpm lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm generate` *(fails: nuxt not found)*
- `pnpm test run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5db8ef7c8333a5019e7e7bca3efb