### PR TITLE
Add runtime env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@
 # Copy this file to `.env` and set values for your environment.
 
 # Strapi CMS
-STRAPI_URL=http://localhost:1337
-STRAPI_TOKEN=
+STRAPI_URL=http://localhost:1337 # Base URL for Strapi CMS
+STRAPI_TOKEN=                   # API token for Strapi CMS
 
 # Public runtime configuration
-NUXT_PUBLIC_SITE_URL=http://localhost:3000
-NUXT_PUBLIC_PLAUSIBLE_DOMAIN=
+NUXT_PUBLIC_SITE_URL=http://localhost:3000 # Public site URL
+NUXT_PUBLIC_PLAUSIBLE_DOMAIN=             # Plausible analytics domain

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,11 +35,11 @@ export default defineNuxtConfig({
     }
   },
   runtimeConfig: {
-    strapiToken: process.env.STRAPI_TOKEN,
+    strapiToken: process.env.STRAPI_TOKEN, // private token for Strapi CMS
     public: {
-      strapiUrl: process.env.STRAPI_URL || 'http://localhost:1337',
-      plausibleDomain: process.env.NUXT_PUBLIC_PLAUSIBLE_DOMAIN,
-      siteUrl: process.env.NUXT_PUBLIC_SITE_URL
+      strapiUrl: process.env.STRAPI_URL || 'http://localhost:1337', // Strapi base URL
+      plausibleDomain: process.env.NUXT_PUBLIC_PLAUSIBLE_DOMAIN, // Plausible domain
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL // Public site URL
     }
   },
   pwa: {


### PR DESCRIPTION
## Summary
- document runtime environment variables in `.env.example`
- clarify runtimeConfig env vars in `nuxt.config.ts`

## Testing
- `pnpm lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm generate` *(fails: nuxt not found)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f6f349aa08333bb47c7f10be41230