### PR TITLE
Fix clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To get the project up and running locally, follow these steps:
 
 2. **Clone the Repository**:  
    ```bash
-   git clone https://github.com/your-org/nudger-nuxt-front.git
+   git clone https://github.com/open4good/nudger-front.git
    ```
 
 3. **Install Dependencies**:  


### PR DESCRIPTION
## Summary
- update README clone URL to use `open4good/nudger-front`

## Testing
- `pnpm lint` *(fails: cannot find package `@nuxt/eslint-config`)*
- `pnpm generate` *(fails: `nuxt` not found)*
- `pnpm test run` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff0143c6c8333b19e2804cc29e61f