### PR TITLE
Add format and API generation checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - run: pnpm install --frozen-lockfile
+      - run: pnpm format
+      - run: pnpm generate:api
+      - run: git diff --exit-code src/api/client.ts
       - run: pnpm lint
       - run: pnpm generate
       - run: pnpm test run


### PR DESCRIPTION
## Summary
- run `pnpm format` in CI
- generate API client and fail if it changes

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_6850080309dc83339e923867d0ca7725