### PR TITLE
Add preview verification in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,11 @@ jobs:
       - run: pnpm lint
       - run: pnpm generate
       - run: pnpm test run
+      - run: pnpm build
+      - name: Verify production build
+        run: |
+          pnpm preview &
+          PREVIEW_PID=$!
+          npx wait-on http://localhost:3000
+          curl -sf http://localhost:3000
+          kill $PREVIEW_PID

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ To get the project up and running locally, follow these steps:
 8. **Other Useful Scripts**:
    - `pnpm lint` – run ESLint
    - `pnpm test` – run tests with Vitest
-   - `pnpm storybook` – launch Storybook
+ - `pnpm storybook` – launch Storybook
   - `pnpm generate:api` – regenerate TypeScript API client
+  - `pnpm preview` – serve the production build locally
   - `pnpm build:ssr` – build with increased memory
   - `pnpm storybook:build` – build Storybook static site
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "build:ssr": "NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
+    "preview": "nuxt preview",
     "generate": "nuxt generate",
     "lint": "eslint .",
     "format": "prettier --check .",


### PR DESCRIPTION
## Summary
- run production build and verify it via pnpm preview in CI
- expose `pnpm preview` script
- document preview script in README

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm test run`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685041cdba748333b39c64ca2f2e95d3