### PR TITLE
Enable dev sourcemaps in Vite config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -78,6 +78,9 @@ export default defineNuxtConfig({
   vite: {
     workerThreads: true,
     cacheDir: '.nuxt/.vite-cache',
+    css: {
+      devSourcemap: true
+    }
   },
   // Experimental Nuxt features
   experimental: {


### PR DESCRIPTION
## Summary
- add `css.devSourcemap` to Vite settings to generate sourcemaps

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm test run`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68504d0234e0833381bb3c7b14fa6ec5