### PR TITLE
Add server-side LazyHydrate stub

### DIFF
--- a/src/plugins/islands.server.spec.ts
+++ b/src/plugins/islands.server.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import plugin from './islands.server'
+
+vi.mock('#app', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defineNuxtPlugin: (fn: any) => fn
+}))
+
+describe('islands server plugin', () => {
+  it('registers LazyHydrate stub', () => {
+    const component = vi.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nuxtApp = { vueApp: { component } } as any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)(nuxtApp)
+    expect(component).toHaveBeenCalled()
+    const args = component.mock.calls[0]
+    expect(args[0]).toBe('LazyHydrate')
+    const comp = args[1]
+    const slot = vi.fn()
+    const render = comp.setup({}, { slots: { default: slot } })
+    render()
+    expect(slot).toHaveBeenCalledWith({ hydrated: true })
+  })
+})

--- a/src/plugins/islands.server.ts
+++ b/src/plugins/islands.server.ts
@@ -1,0 +1,9 @@
+import { defineNuxtPlugin } from '#app'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component('LazyHydrate', {
+    setup(_, { slots }) {
+      return () => slots.default?.({ hydrated: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- support SSR by stubbing LazyHydrate on the server
- test the new islands server plugin

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68504ce7d58c8333a53b304799f6044a