### PR TITLE
Add BASE_URL variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ STRAPI_TOKEN=                   # API token for Strapi CMS
 # Public runtime configuration
 NUXT_PUBLIC_SITE_URL=http://localhost:3000 # Public site URL
 NUXT_PUBLIC_PLAUSIBLE_DOMAIN=             # Plausible analytics domain
-# TODO : Missing base url
+BASE_URL=/                                # Router base path

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ To get the project up and running locally, follow these steps:
    Copy `.env.example` to `.env` and set the following:
    - `STRAPI_URL`: Base URL of the Strapi CMS (e.g. `http://localhost:1337`)
    - `STRAPI_TOKEN`: API access token for Strapi (read-only)
-   - Other optional variables: `NUXT_PUBLIC_SITE_URL`, etc.  
+   - `BASE_URL`: Base path for the Nuxt app (default `/`)
+   - Other optional variables: `NUXT_PUBLIC_SITE_URL`, etc.
      These are declared in `nuxt.config.ts` under `runtimeConfig`.
 
 5. **Run the Dev Server**:  


### PR DESCRIPTION
## Summary
- add `BASE_URL` to `.env.example`
- document this variable in the README

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm test run`

------
https://chatgpt.com/codex/tasks/task_e_68504cd072288333b714e19d22671dd0