### PR TITLE
fix: preserve tailwind default colors

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,7 @@ export default {
   // Custom theme values. Colors come from `tokens.config.json` if defined,
   // otherwise Tailwind's defaults are used.
   theme: {
-    colors: {}
+    extend: {}
   },
 
   // Extra Tailwind plugins to load


### PR DESCRIPTION
## Summary
- update tailwind theme config to avoid overriding default colors

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68504cca040c833392fdef2dc11110be