### PR TITLE
ci: make URL checks configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      URL_CHECKS: |
+        / 200
+        /sitemap.xml 200
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -21,6 +25,24 @@ jobs:
           PREVIEW_PID=$!
           trap "kill $PREVIEW_PID" EXIT
           npx wait-on http://localhost:3000
-          for route in / /sitemap.xml; do
-            curl -sf "http://localhost:3000$route"
-          done
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            set -- $line
+            route=$1
+            expected_status=$2
+            shift 2
+            expected_content="$*"
+            tmpfile=$(mktemp)
+            status=$(curl -s -o "$tmpfile" -w '%{http_code}' "http://localhost:3000$route")
+            if [ "$status" != "$expected_status" ]; then
+              echo "Unexpected status for $route: $status (expected $expected_status)"
+              cat "$tmpfile"
+              exit 1
+            fi
+            if [ -n "$expected_content" ] && ! grep -q "$expected_content" "$tmpfile"; then
+              echo "Expected content not found for $route"
+              cat "$tmpfile"
+              exit 1
+            fi
+            rm "$tmpfile"
+          done <<< "$URL_CHECKS"

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ export const Primary = {
 - CI likely includes:
   - Tests and lint on PRs
   - Semantic release (automated versioning via commit messages)
+  - Production build verification of URLs defined in `URL_CHECKS` in
+    `.github/workflows/ci.yml`
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- externalize URL checks for preview build
- allow custom HTTP code and content assertions
- document the new `URL_CHECKS` variable in the README

## Testing
- `pnpm lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm test run` *(fails: vitest not found)*
- `pnpm generate` *(fails: nuxt not found)*
- `pnpm storybook` *(fails: storybook command not found)*
- `pnpm preview` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851205b82288333b44b24e7b8e7057b